### PR TITLE
Adds two keyboards shortcuts  for use in the input text field

### DIFF
--- a/src/ui/AnotherQuickSwitcherModal.ts
+++ b/src/ui/AnotherQuickSwitcherModal.ts
@@ -92,38 +92,9 @@ export class AnotherQuickSwitcherModal
     });
     // Delete whole input line
     this.scope.register(["Mod"], "D", () => {
-      const elem = this.inputEl;
-      const str = elem.value;
-      elem.setSelectionRange(0, str.length);
-      elem.setRangeText("");
-    });
-    // Delete word at cursor or before cursor if at end of string
-    this.scope.register(["Mod"], "W", () => {
-      const elem = this.inputEl;
-      let curpos = elem.selectionStart;
-      if (curpos === null) {
-        curpos = 0;
-      }
-      let str = elem.value;
-      const endstr = str.substring(curpos);
-      // when CTRL+W is applied at the end of the input but to the right of
-      //   the last word, pretend that it was applied inside the last word of the input
-      if (endstr.match(/^\s*$/)) {
-        str = str.replace(/\s+$/, "");
-      }
-      let idx1 = str.lastIndexOf(' ', curpos);
-      if (idx1 == -1) {
-        idx1 = 0;
-      }
-      else {
-        idx1 += 1;
-      }
-      let idx2 = str.indexOf(' ', curpos);
-      if (idx2 == -1) {
-        idx2 = str.length;
-      }
-      elem.setSelectionRange(idx1, idx2);
-      elem.setRangeText("");
+      this.inputEl.select();
+      this.inputEl.setRangeText("");
+      this.inputEl.dispatchEvent(new Event("input"));
     });
 
     const phantomItems = this.settings.showExistingFilesOnly

--- a/src/ui/AnotherQuickSwitcherModal.ts
+++ b/src/ui/AnotherQuickSwitcherModal.ts
@@ -90,6 +90,41 @@ export class AnotherQuickSwitcherModal
     this.scope.register(["Mod"], "K", () => {
       document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp" }));
     });
+    // Delete whole input line
+    this.scope.register(["Mod"], "D", () => {
+      const elem = this.inputEl;
+      const str = elem.value;
+      elem.setSelectionRange(0, str.length);
+      elem.setRangeText("");
+    });
+    // Delete word at cursor or before cursor if at end of string
+    this.scope.register(["Mod"], "W", () => {
+      const elem = this.inputEl;
+      let curpos = elem.selectionStart;
+      if (curpos === null) {
+        curpos = 0;
+      }
+      let str = elem.value;
+      const endstr = str.substring(curpos);
+      // when CTRL+W is applied at the end of the input but to the right of
+      //   the last word, pretend that it was applied inside the last word of the input
+      if (endstr.match(/^\s*$/)) {
+        str = str.replace(/\s+$/, "");
+      }
+      let idx1 = str.lastIndexOf(' ', curpos);
+      if (idx1 == -1) {
+        idx1 = 0;
+      }
+      else {
+        idx1 += 1;
+      }
+      let idx2 = str.indexOf(' ', curpos);
+      if (idx2 == -1) {
+        idx2 = str.length;
+      }
+      elem.setSelectionRange(idx1, idx2);
+      elem.setRangeText("");
+    });
 
     const phantomItems = this.settings.showExistingFilesOnly
       ? []


### PR DESCRIPTION
This was an additional idea I got after submitting issue #31. I am starting to learn Javascript so I thought I would try create a PR for learning purposes.

This PR adds two keyboard shortcuts for use in the input text field. These are primarily useful if the user is using the switcher to create a new file (not open an existing file). The user can then start typing to view the currently existing notes with similar names, then delete some of the search terms (easily) -- or all of them -- to create a new note name. Now, that he has investigated the current existing file names (using the switcher for previewing purposes) he can better choose a good name for the new note. 

The first keyboard shortcut will delete all text in the input field. 

The second keyboard shortcut deletes the word under the cursor. 

What do you think?

The problem I have with this code, is how to update the suggestion list after deleting a word. If I press CTRL+W to delete the current word, it deletes the word from the input field. So that is working as it should, but the suggestion list does not update before I start typing new characters. Any idea how this can be done?

Also, if you could review the code I have written so far? That would be great!
