### PR TITLE
fix: support supercharged links

### DIFF
--- a/src/ui/suggestion-factory.ts
+++ b/src/ui/suggestion-factory.ts
@@ -46,7 +46,7 @@ function createItemDiv(
       cls: "another-quick-switcher__item__hot-key-guide",
       text: `${item.order! + 1}`,
     });
-    titleDiv.appendChild(hotKeyGuide);
+    entryDiv.appendChild(hotKeyGuide);
   }
 
   if (options.showDirectory) {


### PR DESCRIPTION
![screenshot](https://user-images.githubusercontent.com/83140328/176150909-aa530ef3-830a-4535-8805-160c9233fb11.png)

@chrisgrieser Any ideas for updating the CSS to make the hotkey guides appear next to the title?

Closes #51.