### PR TITLE
Added the ability to go to the line of a heading when chosen

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,3 @@
+[*.ts]
+indent_style = space
+indent_size = 2

--- a/src/ui/AnotherQuickSwitcherModal.ts
+++ b/src/ui/AnotherQuickSwitcherModal.ts
@@ -5,9 +5,11 @@ import {
   Notice,
   parseFrontMatterAliases,
   parseFrontMatterTags,
+  resolveSubpath,
   SuggestModal,
   TFile,
 } from "obsidian";
+import type { HeadingSubpathResult } from 'obsidian';
 import {
   excludeItems,
   includeItems,
@@ -572,10 +574,24 @@ export class AnotherQuickSwitcherModal
       fileToOpened = await this.app.vault.create(item.file.path, "");
     }
 
-    const offset =
-      this.command.searchTarget === "backlink"
-        ? this.appHelper.findFirstLinkOffset(item.file, this.originFile!) // backlinkの候補がある場合はかならずoriginFileが存在する
-        : undefined;
+    let offset = undefined;
+    let line = undefined;
+    if (this.command.searchTarget === 'backlink') {
+      offset = this.appHelper.findFirstLinkOffset(item.file, this.originFile!); // backlinkの候補がある場合はかならずoriginFileが存在する
+    } else if (this.command.searchTarget === 'file') {
+      // Try to enrich the result with a position if the first match includes one
+      if (item.matchResults.length > 0 && item.matchResults[0].type === 'header') {
+        // The match is a header, let's go to that header when opening the file
+        const result = item.matchResults[0];
+        const cache = app.metadataCache.getFileCache(item.file);
+        if (cache && result.meta && result.meta.length > 0) {
+          const path = resolveSubpath(cache,  result.meta[0]);
+          if (path && path.type === 'heading') {
+            line = path.current.position.start.line;
+          }
+        }
+      }
+    }
 
     if (!option.keepOpen) {
       if (leaf === "same-tab") {
@@ -583,7 +599,7 @@ export class AnotherQuickSwitcherModal
       }
       this.close();
     }
-    this.appHelper.openFile(fileToOpened, { leaf, offset });
+    this.appHelper.openFile(fileToOpened, { leaf, offset, line });
     return fileToOpened;
   }
 


### PR DESCRIPTION
This is a pretty simple, yet very useful, tweak. When the selected suggestions includes a header, and the user accepts the suggestion, the file with the result opens in the correct line.
(On a different matter, I added an `.editorconfig` file that would make it easier to contribute code to this project, by making supported editors behave nicely with the project's indentation style.)