### PR TITLE
redirect to target file

### DIFF
--- a/src/ui/AnotherQuickSwitcherModal.ts
+++ b/src/ui/AnotherQuickSwitcherModal.ts
@@ -33,6 +33,7 @@ import { createInstructions, quickResultSelectionModifier } from "src/keys";
 import { FILTER, HEADER, LINK, SEARCH, TAG } from "./icons";
 import { ExhaustiveError } from "../errors";
 import { setFloatingModal } from "./modal";
+import { tryRedirect } from "../utils/redirect-utils";
 
 function buildLogMessage(message: string, msec: number) {
   return `${message}: ${Math.round(msec)}[ms]`;
@@ -568,6 +569,8 @@ export class AnotherQuickSwitcherModal
     if (item.phantom) {
       fileToOpened = await this.app.vault.create(item.file.path, "");
     }
+
+	fileToOpened = tryRedirect(fileToOpened, this.app);
 
     let offset: number | undefined;
     switch (this.command.searchTarget) {

--- a/src/utils/redirect-utils.ts
+++ b/src/utils/redirect-utils.ts
@@ -1,0 +1,34 @@
+function isYamlSayRedirect(cachedMetadata) {
+	let frontMatter = cachedMetadata == null ? void 0 : cachedMetadata.frontmatter; // get yaml area
+	let redirectInYaml = (frontMatter == null ? void 0 : frontMatter.redirect) || (frontMatter == null ? void 0 : frontMatter.redirects); // get attribute in yaml whose key is redirect(s)
+	return redirectInYaml == true;
+}
+
+function isTagSayRedirect(cachedMetadata) {
+	let tags = cachedMetadata == null ? void 0 : cachedMetadata.tags;
+	if ( tags == null ) return false;
+	for (let i=0; i< tags.length; i++) {
+		let tag = tags[i];
+		if ( tag.tag.toUpperCase() === "#REDIRECT" ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+export function tryRedirect(fileToOpened, app) {
+    let _a1;
+    let _b;
+    let _c;
+    let _d;
+    
+    let cachedMetadata = (_a1 = app.metadataCache.getFileCache(fileToOpened)) == null ? void 0 : _a1;
+	let isRedirect = isYamlSayRedirect(cachedMetadata) || isTagSayRedirect(cachedMetadata);
+	if ( isRedirect ) {
+		let firstLink = cachedMetadata == null ? void 0 : (_b = _a1.links) == null ? void 0 : _b.length <= 0 ? void 0 : (_c = _b[0]) == null ? void 0 : (_d = _c.link) == null ? void 0 : _d;
+		let redirectFile = (firstLink == null ? void 0 : app.metadataCache.getFirstLinkpathDest(firstLink, fileToOpened.path));
+        fileToOpened = (redirectFile == null ? fileToOpened : redirectFile); // overwrite file to open
+	}
+	
+	return fileToOpened;
+}


### PR DESCRIPTION
what feature?
redirect to target file, while user is opening a redirection file

what is target file and redirection file?
sometimes I want to set a alias for a file, 
for example, 
I want to set a alias `JS` for `JavaScript`, 
I create two file, `JS.md` & `JavaScript.md`, 
I want to redirect to `JavaScript.md` while opening `JS.md`, 
`JavaScript.md` is called the target file, 
`JS.md` is called the redirection file, 

what is the format of a redirection file?
first, 
mark a redirection file . 
according to source codes in `redirect-utils.ts`, 
inside frontMatter, 
if there is a yaml-tag named as `redirect/redirects`, and it's values is `true`, 
or, 
outside frontMatter, 
if there is a tag named as `redirect`, 
then it is a redirection file, 
second, 
set the link of target file . 
the first link in file, will be recognized as the link of target file

how it redirect?
when opening a file, 
once find the tag of redirection file, 
try to read the first link in file, 
replace variable `fileToOpen` if link exists
