### PR TITLE
Fix #171 (History corruption on close)

### DIFF
--- a/src/app-helper.ts
+++ b/src/app-helper.ts
@@ -1,7 +1,6 @@
 import {
   App,
   Editor,
-  EditorRange,
   FileView,
   getLinkpath,
   HeadingCache,
@@ -12,6 +11,7 @@ import {
   TFolder,
   Vault,
   View,
+  ViewState,
   Workspace,
   WorkspaceLeaf,
 } from "obsidian";
@@ -65,6 +65,9 @@ interface UnsafeAppInterface {
     openPopoutLeaf(): WorkspaceLeaf;
   };
   openWithDefaultApp(path: string): unknown;
+  viewRegistry: {
+    getTypeByExtension(ext: string): string
+  }
 }
 
 interface UnSafeLayoutChild {
@@ -85,33 +88,6 @@ interface UnsafeLayouts {
   main: UnSafeLayout;
   right: UnSafeLayout;
 }
-interface UnSafeWorkspaceLeaf extends WorkspaceLeaf {
-  history: {
-    backHistory: UnsafeHistory[];
-    forwardHistory: UnsafeHistory[];
-    updateState(history: UnsafeHistory): Promise<unknown>;
-  };
-  getHistoryState(): UnsafeHistory;
-}
-export interface UnsafeHistory {
-  title: string;
-  icon: string;
-  state: UnsafeState;
-  eState: UnsafeEState;
-}
-interface UnsafeState {
-  type: "markdown" | string;
-  state: {
-    file: string;
-    mode: string;
-    backlinks: unknown;
-    source: boolean;
-  };
-}
-interface UnsafeEState {
-  cursor: EditorRange;
-}
-
 interface UnsafeCanvasView extends View {
   canvas: UnsafeCanvas;
   requestSave(): unknown;
@@ -131,6 +107,12 @@ interface UnsafeCanvas {
   }): UnsafeCardLayout;
 }
 
+export type CaptureState = {
+  leaf: WorkspaceLeaf,
+  state: ViewState,
+  eState: any,
+}
+
 export type LeafType =
   | "same-tab"
   | "new-tab"
@@ -143,6 +125,7 @@ type OpenFileOption = {
   leaf: LeafType;
   offset?: number;
   line?: number;
+  inplace?: boolean;
 };
 
 export class AppHelper {
@@ -341,70 +324,80 @@ export class AppHelper {
     return abstractFile as TFile;
   }
 
-  openFile(file: TFile, option: Partial<OpenFileOption> = {}) {
+  captureState(): CaptureState {
+    const leaf = app.workspace.getLeaf();
+    return {leaf, state: leaf.getViewState(), eState: leaf.getEphemeralState()}
+  }
+
+  restoreState(capture: CaptureState): Promise<void> {
+    return capture.leaf.setViewState({...capture.state, popstate: true} as ViewState, capture.eState)
+  }
+
+  getOpenState(leaf: WorkspaceLeaf, file: TFile) {
+    let type = this.unsafeApp.viewRegistry.getTypeByExtension(file.extension);
+    if (leaf.view instanceof FileView && leaf.view.canAcceptExtension(file.extension)) {
+      type = leaf.view.getViewType();
+    }
+    return {type, state: {file: file.path}};
+  }
+
+  async openFile(file: TFile, option: Partial<OpenFileOption> = {}, captureState?: CaptureState) {
     const opt: OpenFileOption = {
-      ...{ leaf: "same-tab" },
+      ...{ leaf: "same-tab", inplace: false },
       ...option,
     };
 
-    const _openFile = (leaf: WorkspaceLeaf, background = false) => {
-      leaf
-        .openFile(file, {
-          ...this.unsafeApp.workspace.activeLeaf?.getViewState(),
-          active: !background,
-        })
-        .then(() => {
-          const markdownView =
-            this.unsafeApp.workspace.getActiveViewOfType(MarkdownView);
-          if (markdownView) {
-            if (opt.offset != null) {
-              this.moveTo(opt.offset, markdownView.editor);
-            } else if (opt.line != null) {
-              const p = { line: opt.line, offset: 0, col: 0 };
-              this.moveTo({ start: p, end: p });
-            }
-          }
-        });
-    };
-
-    let leaf: WorkspaceLeaf;
+    let leaf: WorkspaceLeaf|undefined = captureState?.leaf, background: boolean = false;
     switch (opt.leaf) {
       case "same-tab":
-        leaf = this.unsafeApp.workspace.getLeaf();
-        _openFile(leaf);
+        leaf ??= this.unsafeApp.workspace.getLeaf();
         break;
       case "new-tab":
         leaf = this.unsafeApp.workspace.getLeaf(true);
-        _openFile(leaf);
         break;
       case "new-tab-background":
         leaf = this.unsafeApp.workspace.getLeaf(true);
-        _openFile(leaf, true);
+        background = true;
         break;
       case "new-pane-horizontal":
         leaf = this.unsafeApp.workspace.getLeaf("split", "horizontal");
-        _openFile(leaf);
         break;
       case "new-pane-vertical":
         leaf = this.unsafeApp.workspace.getLeaf("split", "vertical");
-        _openFile(leaf);
         break;
       case "new-window":
-        _openFile(this.unsafeApp.workspace.openPopoutLeaf());
+        leaf = this.unsafeApp.workspace.openPopoutLeaf();
         break;
       case "popup":
         const hoverEditorInstance =
           this.unsafeApp.plugins.plugins["obsidian-hover-editor"];
         if (hoverEditorInstance) {
-          leaf = hoverEditorInstance.spawnPopover(undefined, () => {
-            _openFile(leaf);
-          });
+          leaf = hoverEditorInstance.spawnPopover();
         } else {
-          _openFile(this.unsafeApp.workspace.getLeaf());
+          leaf = this.unsafeApp.workspace.getLeaf(true);
         }
         break;
       default:
         throw new ExhaustiveError(opt.leaf);
+    }
+    if (opt.inplace && opt.leaf === "same-tab") {
+      await leaf.setViewState({
+        ...leaf.getViewState(),
+        active: !background,
+        popstate: true,
+        ...this.getOpenState(leaf, file)
+      } as ViewState);
+    } else {
+      await leaf.openFile(file, {...leaf.getViewState(), active: !background});
+    }
+    if (leaf.view instanceof MarkdownView) {
+      const markdownView = leaf.view;
+      if (opt.offset != null) {
+        this.moveTo(opt.offset, markdownView.editor);
+      } else if (opt.line != null) {
+        const p = { line: opt.line, offset: 0, col: 0 };
+        this.moveTo({ start: p, end: p }, markdownView.editor);
+      }
     }
   }
 
@@ -557,53 +550,6 @@ export class AppHelper {
       file,
       pos: { x: x + offset.x, y: y + offset.y },
     });
-  }
-
-  getCurrentLeafHistoryState(leaf: WorkspaceLeaf): UnsafeHistory {
-    const uLeaf = leaf as UnSafeWorkspaceLeaf;
-    return uLeaf.getHistoryState();
-  }
-
-  getCurrentLeafForwardHistories(leaf: WorkspaceLeaf): UnsafeHistory[] {
-    const uLeaf = leaf as UnSafeWorkspaceLeaf;
-    return uLeaf.history.forwardHistory;
-  }
-
-  async resetCurrentLeafHistoryStateTo(
-    leaf: WorkspaceLeaf,
-    history: UnsafeHistory
-  ) {
-    const uLeaf = leaf as UnSafeWorkspaceLeaf;
-    await uLeaf.history.updateState(history);
-
-    const historyIndex = uLeaf.history.backHistory.findIndex(
-      (x) => x.state.state.file === history.state.state.file
-    );
-    this.setLeafBackHistories(
-      leaf,
-      uLeaf.history.backHistory.slice(0, historyIndex)
-    );
-  }
-
-  cloneLeafHistories(leaf: WorkspaceLeaf): {
-    backHistories: UnsafeHistory[];
-    forwardHistories: UnsafeHistory[];
-  } {
-    const uLeaf = leaf as UnSafeWorkspaceLeaf;
-    return {
-      backHistories: uLeaf.history.backHistory.slice(),
-      forwardHistories: uLeaf.history.forwardHistory.slice(),
-    };
-  }
-
-  setLeafForwardHistories(leaf: WorkspaceLeaf, histories: UnsafeHistory[]) {
-    const uLeaf = leaf as UnSafeWorkspaceLeaf;
-    uLeaf.history.forwardHistory = histories;
-  }
-
-  setLeafBackHistories(leaf: WorkspaceLeaf, histories: UnsafeHistory[]) {
-    const uLeaf = leaf as UnSafeWorkspaceLeaf;
-    uLeaf.history.backHistory = histories;
   }
 
   // TODO: Use another interface instead of TFile

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -22,9 +22,6 @@ export function showSearchDialog(
     navigationHistories: [],
     currentNavigationHistoryIndex: 0,
     stackHistory: true,
-    initialHistory: undefined,
-    previewedFiles: [],
-    forwardHistories: undefined,
   });
   modal.open();
 }
@@ -53,7 +50,7 @@ export async function showGrepDialog(app: App, settings: Settings) {
     return;
   }
 
-  const modal = new GrepModal(app, settings, undefined, [], undefined);
+  const modal = new GrepModal(app, settings);
   modal.open();
 }
 

--- a/src/ui/AnotherQuickSwitcherModal.ts
+++ b/src/ui/AnotherQuickSwitcherModal.ts
@@ -181,7 +181,7 @@ export class AnotherQuickSwitcherModal
     }
     if (this.initialState) {
       // restore initial leaf state, undoing any previewing
-      this.navigate(() => this.appHelper.restoreState(this.initialState!));
+      this.navigate(() => this.initialState!.restore());
     }
     this.navigate(this.markClosed);
   }
@@ -794,7 +794,7 @@ export class AnotherQuickSwitcherModal
 
       this.historyRestoreStatus = "doing";
       if (this.initialState) {
-        await this.appHelper.restoreState(this.initialState);
+        await this.initialState.restore();
         this.initialState = undefined;
       }
 

--- a/src/ui/AnotherQuickSwitcherModal.ts
+++ b/src/ui/AnotherQuickSwitcherModal.ts
@@ -23,7 +23,7 @@ import {
   SearchCommand,
   Settings,
 } from "../settings";
-import { AppHelper, LeafType, UnsafeHistory } from "../app-helper";
+import { AppHelper, LeafType, CaptureState } from "../app-helper";
 import { stampMatchResults, SuggestionItem } from "src/matcher";
 import { createElements } from "./suggestion-factory";
 import { filterNoQueryPriorities, sort } from "../sorters";
@@ -64,8 +64,6 @@ export class AnotherQuickSwitcherModal
   currentNavigationHistoryIndex: number;
   stackHistory: boolean;
 
-  previewedFiles: TFile[];
-
   chooser: UnsafeModalInterface<SuggestionItem>["chooser"];
   scope: UnsafeModalInterface<SuggestionItem>["scope"];
 
@@ -77,8 +75,7 @@ export class AnotherQuickSwitcherModal
   command: SearchCommand;
   initialCommand: SearchCommand;
 
-  initialHistory: UnsafeHistory;
-  forwardHistories: UnsafeHistory[];
+  initialState?: CaptureState;  // State of leaf before previewing began
 
   navigationHistoryEl?: HTMLDivElement;
   searchCommandEl?: HTMLDivElement;
@@ -86,9 +83,14 @@ export class AnotherQuickSwitcherModal
   countInputEl?: HTMLDivElement;
   floating: boolean;
   opened: boolean;
-  openInSameLeaf: boolean;
   willSilentClose: boolean = false;
   historyRestoreStatus: "initial" | "doing" | "done" = "initial";
+
+  private markClosed: () => void;
+  isClosed: Promise<void> = new Promise(resolve => {
+    this.markClosed = resolve;
+  });
+  navQueue: Promise<void>;
 
   constructor(args: {
     app: App;
@@ -99,9 +101,8 @@ export class AnotherQuickSwitcherModal
     navigationHistories: CustomSearchHistory[];
     currentNavigationHistoryIndex: number;
     stackHistory: boolean;
-    initialHistory: UnsafeHistory | undefined;
-    previewedFiles: TFile[];
-    forwardHistories: UnsafeHistory[] | undefined;
+    initialState?: CaptureState,
+    navQueue?: Promise<void>,
   }) {
     super(app);
 
@@ -115,15 +116,8 @@ export class AnotherQuickSwitcherModal
     this.navigationHistories = args.navigationHistories;
     this.currentNavigationHistoryIndex = args.currentNavigationHistoryIndex;
     this.stackHistory = args.stackHistory;
-    this.initialHistory =
-      args.initialHistory ??
-      this.appHelper.getCurrentLeafHistoryState(this.app.workspace.getLeaf());
-    this.previewedFiles = args.previewedFiles;
-    this.forwardHistories =
-      args.forwardHistories ??
-      this.appHelper.getCurrentLeafForwardHistories(
-        this.app.workspace.getLeaf()
-      );
+    this.initialState = args.initialState;
+    this.navQueue = args.navQueue ?? Promise.resolve();
 
     this.limit = this.settings.maxNumberOfSuggestions;
     this.setHotkeys();
@@ -153,19 +147,9 @@ export class AnotherQuickSwitcherModal
     );
   }
 
-  async waitForHistoryRestored() {
-    // HACK: For click after preview handling
-    if (this.historyRestoreStatus === "doing") {
-      // @ts-ignore
-      while (this.historyRestoreStatus !== "done") {
-        await sleep(0);
-      }
-    }
-  }
-
-  async safeClose() {
+  safeClose(): Promise<void> {
     this.close();
-    await this.waitForHistoryRestored();
+    return this.isClosed;
   }
 
   onOpen() {
@@ -187,7 +171,6 @@ export class AnotherQuickSwitcherModal
       });
     }
 
-    this.openInSameLeaf = false;
     this.opened = true;
   }
 
@@ -196,28 +179,11 @@ export class AnotherQuickSwitcherModal
     if (this.willSilentClose) {
       return;
     }
-
-    const leaf = this.app.workspace.getLeaf();
-    if (!this.openInSameLeaf) {
-      this.historyRestoreStatus = "doing";
-      this.appHelper
-        .resetCurrentLeafHistoryStateTo(leaf, this.initialHistory)
-        .then(() => {
-          this.appHelper.setLeafForwardHistories(leaf, this.forwardHistories);
-          this.historyRestoreStatus = "done";
-        });
+    if (this.initialState) {
+      // restore initial leaf state, undoing any previewing
+      this.navigate(() => this.appHelper.restoreState(this.initialState!));
     }
-
-    setTimeout(() => {
-      const previewedPaths = this.previewedFiles.map((x) => x.path);
-      const { backHistories } = this.appHelper.cloneLeafHistories(leaf);
-      this.appHelper.setLeafBackHistories(
-        leaf,
-        backHistories.filter(
-          (x) => !previewedPaths.includes(x.state.state.file)
-        )
-      );
-    }, 200);
+    this.navigate(this.markClosed);
   }
 
   silentClose() {
@@ -562,6 +528,10 @@ export class AnotherQuickSwitcherModal
     this.resultContainerEl.appendChild(div);
   }
 
+  navigate(cb: () => any) {
+    this.navQueue = this.navQueue.then(cb);
+  }
+
   async chooseCurrentSuggestion(
     leaf: LeafType,
     option: { keepOpen?: boolean } = {}
@@ -602,13 +572,14 @@ export class AnotherQuickSwitcherModal
     }
 
     if (!option.keepOpen) {
-      if (leaf === "same-tab") {
-        this.openInSameLeaf = true;
-      }
-      await this.safeClose();
+      this.close();
+      this.navigate(() => this.isClosed); // wait for close to finish before navigating
+    } else if (leaf === "same-tab") {
+      // Previewing in same tab; save state if not already saved
+      this.initialState ??= this.appHelper.captureState();
     }
 
-    this.appHelper.openFile(fileToOpened, { leaf, offset });
+    this.navigate(() => this.appHelper.openFile(fileToOpened, {leaf, offset, inplace: option.keepOpen}, this.initialState));
     return fileToOpened;
   }
 
@@ -640,11 +611,9 @@ export class AnotherQuickSwitcherModal
       return true;
     }
 
-    if (leafType === "same-tab") {
-      this.openInSameLeaf = true;
-    }
     this.close();
-    this.appHelper.openFile(file, { leaf: leafType });
+    this.navigate(() => this.isClosed);
+    this.navigate(() => this.appHelper.openFile(file, { leaf: leafType }));
     return false;
   }
 
@@ -744,16 +713,13 @@ export class AnotherQuickSwitcherModal
         );
     });
 
-    this.registerKeys("preview", async () => {
+    this.registerKeys("preview", () => {
       if (!this.floating) {
         this.enableFloating();
       }
-      const file = await this.chooseCurrentSuggestion("same-tab", {
+      this.chooseCurrentSuggestion("same-tab", {
         keepOpen: true,
       });
-      if (file) {
-        this.previewedFiles.push(file);
-      }
     });
 
     this.registerKeys("create", async () => {
@@ -790,6 +756,7 @@ export class AnotherQuickSwitcherModal
       }
 
       this.close();
+      await this.isClosed;
 
       const urls = await this.appHelper.findExternalLinkUrls(fileToOpened);
       if (urls.length > 0) {
@@ -826,13 +793,10 @@ export class AnotherQuickSwitcherModal
       }
 
       this.historyRestoreStatus = "doing";
-      const leaf = this.app.workspace.getLeaf();
-      await this.appHelper
-        .resetCurrentLeafHistoryStateTo(leaf, this.initialHistory)
-        .then(() => {
-          this.appHelper.setLeafForwardHistories(leaf, this.forwardHistories);
-          this.historyRestoreStatus = "done";
-        });
+      if (this.initialState) {
+        await this.appHelper.restoreState(this.initialState);
+        this.initialState = undefined;
+      }
 
       if (this.appHelper.isActiveLeafCanvas()) {
         this.appHelper.addFileToCanvas(file);
@@ -843,10 +807,6 @@ export class AnotherQuickSwitcherModal
         );
         this.appHelper.insertStringToActiveFile("\n");
       }
-
-      this.initialHistory = this.appHelper.getCurrentLeafHistoryState(
-        this.app.workspace.getLeaf()
-      );
     });
 
     this.registerKeys("insert all to editor", async () => {
@@ -896,9 +856,8 @@ export class AnotherQuickSwitcherModal
         ],
         currentNavigationHistoryIndex: this.currentNavigationHistoryIndex + 1,
         stackHistory: true,
-        initialHistory: this.initialHistory,
-        previewedFiles: this.previewedFiles,
-        forwardHistories: this.forwardHistories,
+        initialState: this.initialState,
+        navQueue: this.navQueue,
       });
       modal.open();
     };
@@ -930,9 +889,8 @@ export class AnotherQuickSwitcherModal
         navigationHistories: this.navigationHistories,
         currentNavigationHistoryIndex: index,
         stackHistory: false,
-        initialHistory: this.initialHistory,
-        previewedFiles: this.previewedFiles,
-        forwardHistories: this.forwardHistories,
+        initialState: this.initialState,
+        navQueue: this.navQueue,
       });
       modal.open();
     };

--- a/src/ui/GrepModal.ts
+++ b/src/ui/GrepModal.ts
@@ -1,6 +1,6 @@
 import { App, SuggestModal, TFile } from "obsidian";
 import { Hotkeys, Settings } from "../settings";
-import { AppHelper, LeafType, UnsafeHistory } from "../app-helper";
+import { AppHelper, LeafType, CaptureState } from "../app-helper";
 import { rg } from "../utils/ripgrep";
 import {
   createInstruction,
@@ -50,9 +50,7 @@ export class GrepModal
 {
   appHelper: AppHelper;
   settings: Settings;
-  initialHistory: UnsafeHistory;
-  previewedFiles: TFile[];
-  forwardHistories: UnsafeHistory[];
+  initialState: CaptureState;  // State of leaf before previewing began
 
   chooser: UnsafeModalInterface<SuggestionItem>["chooser"];
   scope: UnsafeModalInterface<SuggestionItem>["scope"];
@@ -79,15 +77,15 @@ export class GrepModal
     ev: HTMLElementEventMap["keydown"]
   ) => any;
 
-  openInSameLeaf: boolean;
-  historyRestoreStatus: "initial" | "doing" | "done" = "initial";
+  private markClosed: () => void;
+  isClosed: Promise<void> = new Promise(resolve => {
+    this.markClosed = resolve;
+  });
+  navQueue: Promise<void> = Promise.resolve();
 
   constructor(
     app: App,
     settings: Settings,
-    initialHistory: UnsafeHistory | undefined,
-    previewedFiles: TFile[],
-    forwardHistories: UnsafeHistory[] | undefined
   ) {
     super(app);
     this.suggestions = globalInternalStorage.items;
@@ -98,15 +96,6 @@ export class GrepModal
     this.appHelper = new AppHelper(app);
     this.settings = settings;
     this.limit = 255;
-    this.initialHistory =
-      initialHistory ??
-      this.appHelper.getCurrentLeafHistoryState(this.app.workspace.getLeaf());
-    this.previewedFiles = previewedFiles;
-    this.forwardHistories =
-      forwardHistories ??
-      this.appHelper.getCurrentLeafForwardHistories(
-        this.app.workspace.getLeaf()
-      );
 
     const searchCmd = this.settings.hotkeys.grep.search.at(0);
     if (searchCmd) {
@@ -127,7 +116,6 @@ export class GrepModal
     super.onOpen();
     setFloatingModal(this.appHelper);
 
-    this.openInSameLeaf = false;
     this.basePath = globalInternalStorage.basePath ?? "";
 
     window.setTimeout(() => {
@@ -224,27 +212,11 @@ export class GrepModal
       this.basePathInputElKeydownEventListener
     );
 
-    const leaf = this.app.workspace.getLeaf();
-    if (!this.openInSameLeaf) {
-      this.historyRestoreStatus = "doing";
-      this.appHelper
-        .resetCurrentLeafHistoryStateTo(leaf, this.initialHistory)
-        .then(() => {
-          this.appHelper.setLeafForwardHistories(leaf, this.forwardHistories);
-          this.historyRestoreStatus = "done";
-        });
+    if (this.initialState) {
+      // restore initial leaf state, undoing any previewing
+      this.navigate(() => this.appHelper.restoreState(this.initialState));
     }
-
-    setTimeout(() => {
-      const previewedPaths = this.previewedFiles.map((x) => x.path);
-      const { backHistories } = this.appHelper.cloneLeafHistories(leaf);
-      this.appHelper.setLeafBackHistories(
-        leaf,
-        backHistories.filter(
-          (x) => !previewedPaths.includes(x.state.state.file)
-        )
-      );
-    }, 200);
+    this.navigate(this.markClosed);
   }
 
   async searchSuggestions(query: string): Promise<SuggestionItem[]> {
@@ -398,6 +370,10 @@ export class GrepModal
     el.appendChild(itemDiv);
   }
 
+  navigate(cb: () => any) {
+    this.navQueue = this.navQueue.then(cb);
+  }
+
   async chooseCurrentSuggestion(
     leaf: LeafType,
     option: { keepOpen?: boolean } = {}
@@ -408,24 +384,17 @@ export class GrepModal
     }
 
     if (!option.keepOpen) {
-      if (leaf === "same-tab") {
-        this.openInSameLeaf = true;
-      }
       this.close();
+      this.navigate(() => this.isClosed); // wait for close to finish before navigating
+    } else if (leaf === "same-tab") {
+      // Previewing in same tab; save state if not already saved
+      this.initialState ??= this.appHelper.captureState();
     }
-
-    // HACK: For click after preview handling
-    if (this.historyRestoreStatus === "doing") {
-      // @ts-ignore
-      while (this.historyRestoreStatus !== "done") {
-        await sleep(0);
-      }
-    }
-
-    this.appHelper.openFile(item.file, {
+    this.navigate(() => this.appHelper.openFile(item.file, {
       leaf: leaf,
       line: item.lineNumber - 1,
-    });
+      inplace: option.keepOpen
+    }, this.initialState));
     return item.file;
   }
 
@@ -569,9 +538,6 @@ export class GrepModal
       const file = await this.chooseCurrentSuggestion("same-tab", {
         keepOpen: true,
       });
-      if (file) {
-        this.previewedFiles.push(file);
-      }
     });
 
     const modifierKey = this.settings.userAltInsteadOfModForQuickResultSelection

--- a/src/ui/GrepModal.ts
+++ b/src/ui/GrepModal.ts
@@ -214,7 +214,7 @@ export class GrepModal
 
     if (this.initialState) {
       // restore initial leaf state, undoing any previewing
-      this.navigate(() => this.appHelper.restoreState(this.initialState));
+      this.navigate(() => this.initialState.restore());
     }
     this.navigate(this.markClosed);
   }


### PR DESCRIPTION
This PR drops all the history manipulation code and instead does previews in-place in history (so the history of the current tab never changes).  Basically, instead of relying on the undocumented internals of Obsidian history, this new version relies on the undocumented `popstate` field in ViewState (that updates the current state without affecting history).