### PR TITLE
fix: empty leaf creation

### DIFF
--- a/src/ui/AnotherQuickSwitcherModal.ts
+++ b/src/ui/AnotherQuickSwitcherModal.ts
@@ -6,7 +6,7 @@ import {
   parseFrontMatterAliases,
   parseFrontMatterTags,
   SuggestModal,
-  TFile,
+  TFile, View, WorkspaceLeaf,
 } from "obsidian";
 import {
   excludeItems,
@@ -117,12 +117,12 @@ export class AnotherQuickSwitcherModal
     this.stackHistory = args.stackHistory;
     this.initialHistory =
       args.initialHistory ??
-      this.appHelper.getCurrentLeafHistoryState(this.app.workspace.getLeaf());
+      this.appHelper.getCurrentLeafHistoryState(this.app.workspace.getActiveViewOfType(View)?.leaf as WorkspaceLeaf);
     this.previewedFiles = args.previewedFiles;
     this.forwardHistories =
       args.forwardHistories ??
       this.appHelper.getCurrentLeafForwardHistories(
-        this.app.workspace.getLeaf()
+        this.app.workspace.getActiveViewOfType(View)?.leaf as WorkspaceLeaf
       );
 
     this.limit = this.settings.maxNumberOfSuggestions;
@@ -197,7 +197,7 @@ export class AnotherQuickSwitcherModal
       return;
     }
 
-    const leaf = this.app.workspace.getLeaf();
+    const leaf = this.app.workspace.getActiveViewOfType(View)?.leaf as WorkspaceLeaf
     if (!this.openInSameLeaf) {
       this.historyRestoreStatus = "doing";
       this.appHelper

--- a/src/ui/GrepModal.ts
+++ b/src/ui/GrepModal.ts
@@ -1,4 +1,4 @@
-import { App, SuggestModal, TFile } from "obsidian";
+import {App, SuggestModal, TFile, View, WorkspaceLeaf} from "obsidian";
 import { Hotkeys, Settings } from "../settings";
 import { AppHelper, LeafType, UnsafeHistory } from "../app-helper";
 import { rg } from "../utils/ripgrep";
@@ -100,12 +100,12 @@ export class GrepModal
     this.limit = 255;
     this.initialHistory =
       initialHistory ??
-      this.appHelper.getCurrentLeafHistoryState(this.app.workspace.getLeaf());
+      this.appHelper.getCurrentLeafHistoryState(this.app.workspace.getActiveViewOfType(View)?.leaf as WorkspaceLeaf);
     this.previewedFiles = previewedFiles;
     this.forwardHistories =
       forwardHistories ??
       this.appHelper.getCurrentLeafForwardHistories(
-        this.app.workspace.getLeaf()
+        this.app.workspace.getActiveViewOfType(View)?.leaf as WorkspaceLeaf
       );
 
     const searchCmd = this.settings.hotkeys.grep.search.at(0);
@@ -224,7 +224,7 @@ export class GrepModal
       this.basePathInputElKeydownEventListener
     );
 
-    const leaf = this.app.workspace.getLeaf();
+    const leaf = this.app.workspace.getActiveViewOfType(View)?.leaf as WorkspaceLeaf
     if (!this.openInSameLeaf) {
       this.historyRestoreStatus = "doing";
       this.appHelper


### PR DESCRIPTION
Closes #157, at least in my tests. There might be other code where `getLeaf()` shouldn't be used.

This doesn't do any `null` checks and uses `as WorkspaceLeaf` instead. This PR isn't supposed to be merged, just to show how it can be fixed. 
I'd prefer you merge #172. @pjeby, I've noticed that `getLeaf()` is used in your PR. I didn't look into all the uses, but I think you should test the behaviour in pinned tabs/Style settings to check that it doesn't create any empty leaves (see #157) and adjust the code if necessary.

For reference: https://github.com/obsidianmd/obsidian-api/blob/583ba39e3f6c0546de5e5e8742256a60e2d78ebc/obsidian.d.ts#L4023-L4024
