### PR TITLE
fix(css): missing separators for frontmatter value arrays

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -285,9 +285,11 @@
 }
 .another-quick-switcher__item__meta__front_matter__key::after {
   content: ":";
+  margin-right: 3px;
 }
-.another-quick-switcher__item__meta__front_matter__value {
-  margin-left: 3px;
+.another-quick-switcher__item__meta__front_matter__value
+	+ .another-quick-switcher__item__meta__front_matter__value::before {
+	content: ", ";
 }
 
 .another-quick-switcher__item__meta__score {


### PR DESCRIPTION
Hi 👋 

A minor bug fix: when you have frontmatter values, there is no visual separation between values. that way, it's not possible to tell whether something is one value, or a list of values.

For example, here the `means` key has actually two values, `particularly…` and `allow access…`. However, due to the lack of a separator, it looks like one long string value.

![Pasted image 2024-07-10 at 18 12 16](https://github.com/tadashi-aikawa/obsidian-another-quick-switcher/assets/73286100/d54afa17-b9db-4ef8-9e60-dc21b726dc7c)

![Pasted image 2024-07-10 at 18 12 07](https://github.com/tadashi-aikawa/obsidian-another-quick-switcher/assets/73286100/8e81c014-6d38-4673-9b34-cdc80614f494)

The PR fixes that by adding a `,` in between values via CSS:
![Pasted image 2024-07-10 at 18 29 10](https://github.com/tadashi-aikawa/obsidian-another-quick-switcher/assets/73286100/f253d1aa-027d-4034-bf3d-5d7049de0913)
