### PR TITLE
fix: null values in property display breaking search

### DIFF
--- a/src/ui/suggestion-factory.ts
+++ b/src/ui/suggestion-factory.ts
@@ -137,6 +137,7 @@ function createMetaDiv(args: {
       });
 
       for (const v of [value].flat()) {
+        if (!v) continue;
         frontMatterDiv.createSpan({
           cls: "another-quick-switcher__item__meta__front_matter__value",
           title: v.toString(),


### PR DESCRIPTION
When using displaying properties in a search, that property is unset in one of the files search, the respective search breaks, and the search is missing a few results. Also, the navigation is totally broken, until the query reduces the results to a list of files where the property is always set, effectively making the search mostly unusable in such cases.

```
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'toString')
    at createMetaDiv (plugin:obsidian-another-quick-switcher:2853:20)
    at createElements (plugin:obsidian-another-quick-switcher:2973:73)
    at _AnotherQuickSwitcherModal.renderSuggestion (plugin:obsidian-another-quick-switcher:3351:50)
    at e.setSuggestions (app.js:1:1583474)
    at i (app.js:1:1586474)
    at t.updateSuggestions (app.js:1:1586534)
    at _AnotherQuickSwitcherModal.onOpen (plugin:obsidian-another-quick-switcher:3087:10)
    at e.open (app.js:1:1476803)
    at showSearchDialog (plugin:obsidian-another-quick-switcher:5807:9)
    at callback (plugin:obsidian-another-quick-switcher:5964:11)
```

I looked into it, and the cause is a missing null-check when creating the `div` for a property value.

This PR fixes this issue by adding the missing null check.
